### PR TITLE
gem names ending in a number

### DIFF
--- a/lib/rubygems/commands/open.rb
+++ b/lib/rubygems/commands/open.rb
@@ -42,7 +42,7 @@ class Gem::Commands::OpenCommand < Gem::Command
   end
 
   def search(gemname)
-    regex = /^(.*?)-*([\d.]+[\w]*)?$/
+    regex = /^(.*?)(-+[\d.]+[\w]*)?$/
     _, required_name, required_version = *gemname.match(regex)
 
     gemspecs = Dir["{#{dirs.join(",")}}/*.gemspec"].select do |gemspec|

--- a/test/gem_open_test.rb
+++ b/test/gem_open_test.rb
@@ -117,6 +117,28 @@ class GemOpenTest < Test::Unit::TestCase
     @plugin.execute
   end
 
+  def test_gem_with_alphanumeric_name
+    gemname = "imgur2"
+
+    @plugin.expects(:dirs).returns([File.dirname(__FILE__) + "/resources"])
+
+    @plugin.expects(:options).returns(:args => [gemname])
+    @plugin.expects(:system).with("mate #{@gemdir}/imgur2-1.2.0")
+
+    @plugin.execute
+  end
+
+  def test_gem_with_alphanumeric_name_and_version
+    gemname = "imgur2-1.2.0"
+
+    @plugin.expects(:dirs).returns([File.dirname(__FILE__) + "/resources"])
+
+    @plugin.expects(:options).returns(:args => [gemname])
+    @plugin.expects(:system).with("mate #{@gemdir}/imgur2-1.2.0")
+
+    @plugin.execute
+  end
+
   def test_unset_editor
     ENV["GEM_EDITOR"] = nil
     ENV["EDITOR"] = nil

--- a/test/resources/imgur2-1.2.0.gemspec
+++ b/test/resources/imgur2-1.2.0.gemspec
@@ -1,0 +1,33 @@
+# -*- encoding: utf-8 -*-
+
+Gem::Specification.new do |s|
+  s.name = %q{imgur2}
+  s.version = "1.2.0"
+
+  s.required_rubygems_version = Gem::Requirement.new(">= 0") if s.respond_to? :required_rubygems_version=
+  s.authors = [%q{Aaron Patterson}]
+  s.date = %q{2011-03-28}
+  s.description = %q{Upload stuff to imgur.  Yay.}
+  s.email = [%q{aaron@tenderlovemaking.com}]
+  s.executables = [%q{imgur2}]
+  s.extra_rdoc_files = [%q{Manifest.txt}, %q{CHANGELOG.rdoc}, %q{README.rdoc}]
+  s.files = [%q{bin/imgur2}, %q{Manifest.txt}, %q{CHANGELOG.rdoc}, %q{README.rdoc}]
+  s.homepage = %q{http://github.com/tenderlove/imgur2}
+  s.rdoc_options = [%q{--main}, %q{README.rdoc}]
+  s.require_paths = [%q{lib}]
+  s.rubyforge_project = %q{imgur2}
+  s.rubygems_version = %q{1.8.1}
+  s.summary = %q{Upload stuff to imgur}
+
+  if s.respond_to? :specification_version then
+    s.specification_version = 3
+
+    if Gem::Version.new(Gem::VERSION) >= Gem::Version.new('1.2.0') then
+      s.add_development_dependency(%q<hoe>, [">= 2.9.1"])
+    else
+      s.add_dependency(%q<hoe>, [">= 2.9.1"])
+    end
+  else
+    s.add_dependency(%q<hoe>, [">= 2.9.1"])
+  end
+end


### PR DESCRIPTION
The current regex `/^(.*?)-*([\d.]+[\w]*)?$/` for matching gem names and versions incorrectly assumes trailing numbers from names like `imgur2` are part of the version string. This commit changes that regex to `/^(.*?)(-+[\d.]+[\w]*)?$/`, which will requires a `-` to be part of the version string.

Test cases were added for opening `imgur2` and `imgur2-1.2.0`
