### PR TITLE
Fix SourceIndex.installed_spec_directories deprecation warning

### DIFF
--- a/README.rdoc
+++ b/README.rdoc
@@ -35,7 +35,7 @@ Want some completion? Add this snippet to your <tt>~/.bash_profile</tt> file.
 
       case "$subcmd" in
           open)
-              words=`ruby -rubygems -e 'puts Dir["{#{Gem::SourceIndex.installed_spec_directories.join(",")}}/*.gemspec"].collect {|s| File.basename(s).gsub(/\.gemspec$/, "")}'`
+              words=`ruby -rubygems -e 'puts Dir["{#{Gem::Specification.dirs.join(",")}}/*.gemspec"].collect {|s| File.basename(s).gsub(/\.gemspec$/, "")}'`
               ;;
           *)
               return


### PR DESCRIPTION
The recommendation  about Bash completion in README.rdoc gives this deprecation warning message:

Gem::SourceIndex.installed_spec_directories is deprecated with no
replacement. It will be removed on or after 2011-10-01

With this change it's fixed.

Regards
