### PR TITLE
Improve homepage in gemspec

### DIFF
--- a/gem-open.gemspec
+++ b/gem-open.gemspec
@@ -7,7 +7,7 @@ Gem::Specification.new do |s|
   s.platform    = Gem::Platform::RUBY
   s.authors     = ["Nando Vieira"]
   s.email       = ["fnando.vieira@gmail.com"]
-  s.homepage    = "http://rubygems.org/gems/gem-open"
+  s.homepage    = "https://github.com/fnando/gem-open"
   s.summary     = "Open gems on your favorite editor by running a specific gem command like `gem open nokogiri`."
   s.description = s.summary
 


### PR DESCRIPTION
Common convention has become to set the gemspec homepage to the source repository.