### PR TITLE
Chdir and shellwords

### DIFF
--- a/lib/rubygems/commands/open.rb
+++ b/lib/rubygems/commands/open.rb
@@ -67,7 +67,10 @@ class Gem::Commands::OpenCommand < Gem::Command
     editor = ENV["GEM_EDITOR"] || ENV["EDITOR"]
 
     if editor
-      system *editor.split, spec.full_gem_path
+      path = spec.full_gem_path
+      Dir.chdir(path) do
+        system(*editor.split, path)
+      end
     else
       say "You must set your editor in your .bash_profile or equivalent:"
       say "  export GEM_EDITOR='mate'"

--- a/lib/rubygems/commands/open.rb
+++ b/lib/rubygems/commands/open.rb
@@ -1,3 +1,5 @@
+require "shellwords"
+
 class Gem::Commands::OpenCommand < Gem::Command
   def description
     "Open a gem into your favorite editor"
@@ -69,7 +71,7 @@ class Gem::Commands::OpenCommand < Gem::Command
     if editor
       path = spec.full_gem_path
       Dir.chdir(path) do
-        system(*editor.split, path)
+        system(*Shellwords.split(editor), path)
       end
     else
       say "You must set your editor in your .bash_profile or equivalent:"

--- a/test/gem_open_test.rb
+++ b/test/gem_open_test.rb
@@ -48,6 +48,7 @@ class GemOpenTest < Test::Unit::TestCase
     @plugin.expects(:dirs).returns([File.dirname(__FILE__) + "/resources"])
 
     @plugin.expects(:options).returns(:args => [gemname])
+    Dir.expects(:chdir).with("#{@gemdir}/activesupport-3.0.0.beta3").yields
     @plugin.expects(:system).with("mate", "#{@gemdir}/activesupport-3.0.0.beta3")
 
     @plugin.execute
@@ -62,6 +63,7 @@ class GemOpenTest < Test::Unit::TestCase
     @plugin.expects(:dirs).returns([File.dirname(__FILE__) + "/resources"])
 
     @plugin.expects(:options).returns(:args => [gemname])
+    Dir.expects(:chdir).with("#{@gemdir}/activesupport-3.0.0.beta3").yields
     @plugin.expects(:system).with("vim", "#{@gemdir}/activesupport-3.0.0.beta3")
 
     @plugin.execute
@@ -73,6 +75,7 @@ class GemOpenTest < Test::Unit::TestCase
     @plugin.expects(:dirs).returns([File.dirname(__FILE__) + "/resources"])
 
     @plugin.expects(:options).returns(:args => [gemname])
+    Dir.expects(:chdir).with("#{@gemdir}/activesupport-3.0.0.beta3").yields
     @plugin.expects(:system).with("mate", "#{@gemdir}/activesupport-3.0.0.beta3")
 
     @plugin.execute
@@ -84,6 +87,7 @@ class GemOpenTest < Test::Unit::TestCase
     @plugin.expects(:dirs).returns([File.dirname(__FILE__) + "/resources"])
 
     @plugin.expects(:options).returns(:args => [gemname])
+    Dir.expects(:chdir).with("#{@gemdir}/activesupport-2.3.5").yields
     @plugin.expects(:system).with("mate", "#{@gemdir}/activesupport-2.3.5")
 
     @plugin.execute
@@ -95,6 +99,7 @@ class GemOpenTest < Test::Unit::TestCase
     @plugin.expects(:dirs).returns([File.dirname(__FILE__) + "/resources"])
 
     @plugin.expects(:options).returns(:args => [gemname])
+    Dir.expects(:chdir).with("#{@gemdir}/sinatra-sugar-0.4.1").yields
     @plugin.expects(:system).with("mate", "#{@gemdir}/sinatra-sugar-0.4.1")
 
     @plugin.execute
@@ -106,6 +111,7 @@ class GemOpenTest < Test::Unit::TestCase
     @plugin.expects(:dirs).returns([File.dirname(__FILE__) + "/resources"])
 
     @plugin.expects(:options).returns(:args => [gemname])
+    Dir.expects(:chdir).with("#{@gemdir}/sinatra-sugar-0.4.1").yields
     @plugin.expects(:system).with("mate", "#{@gemdir}/sinatra-sugar-0.4.1")
 
     @plugin.execute
@@ -117,6 +123,7 @@ class GemOpenTest < Test::Unit::TestCase
     @plugin.expects(:dirs).returns([File.dirname(__FILE__) + "/resources"])
 
     @plugin.expects(:options).returns(:args => [gemname])
+    Dir.expects(:chdir).with("#{@gemdir}/imgur2-1.2.0").yields
     @plugin.expects(:system).with("mate", "#{@gemdir}/imgur2-1.2.0")
 
     @plugin.execute
@@ -128,6 +135,7 @@ class GemOpenTest < Test::Unit::TestCase
     @plugin.expects(:dirs).returns([File.dirname(__FILE__) + "/resources"])
 
     @plugin.expects(:options).returns(:args => [gemname])
+    Dir.expects(:chdir).with("#{@gemdir}/imgur2-1.2.0").yields
     @plugin.expects(:system).with("mate", "#{@gemdir}/imgur2-1.2.0")
 
     @plugin.execute

--- a/test/gem_open_test.rb
+++ b/test/gem_open_test.rb
@@ -141,6 +141,19 @@ class GemOpenTest < Test::Unit::TestCase
     @plugin.execute
   end
 
+  def test_parse_editor
+    ENV["GEM_EDITOR"] = "mate -H '/Users/My Home/Code and Stuff'"
+    gemname = "imgur2-1.2.0"
+
+    @plugin.expects(:dirs).returns([File.dirname(__FILE__) + "/resources"])
+
+    @plugin.expects(:options).returns(:args => [gemname])
+    Dir.expects(:chdir).with("#{@gemdir}/imgur2-1.2.0").yields
+    @plugin.expects(:system).with("mate", "-H", "/Users/My Home/Code and Stuff", "#{@gemdir}/imgur2-1.2.0")
+
+    @plugin.execute
+  end
+
   def test_unset_editor
     ENV["GEM_EDITOR"] = nil
     ENV["EDITOR"] = nil


### PR DESCRIPTION
Change directory into the gem directory before executing the editor so the editing process can navigate within the working directory, like how bundler does:
     https://github.com/bundler/bundler/blob/4c54e5f64594986ab187aafa0068b16be8959408/lib/bundler/cli/open.rb#L17-L20

Also use shellwords to split the command before appending the path so quoted arguments are preserved.