### PR TITLE
Default rake task is test

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,3 +8,5 @@ Rake::TestTask.new do |t|
   t.test_files = FileList["test/**/*_test.rb"]
   t.verbose = true
 end
+
+task :default => :test


### PR DESCRIPTION
Make the default rake task `:test`. This is pretty conventional for contributors and testing services like Travis.

Maybe you could add travis for testing? :-)